### PR TITLE
FEAT/fonts, color, layout 테마 세팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,15 @@ import { RouterProvider } from 'react-router-dom'
 
 import GlobalStyles from './styles/GlobalStyle'
 import router from './Routes'
+import { ThemeProvider } from 'styled-components'
+import theme from '@/styles/theme'
 
 function App() {
     return (
-        <>
+        <ThemeProvider theme={theme}>
             <GlobalStyles />
             <RouterProvider router={router} />
-        </>
+        </ThemeProvider>
     )
 }
 

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -1,0 +1,19 @@
+const colors = {
+    background: ' linear-gradient(180deg, #0B0711 0%, rgba(11, 7, 17, 0.9) 100%);',
+    linear: {
+        purple: 'linear-gradient(126.87deg, #635273 16.19%, #B9A1CF 83.65%);',
+        gray: 'linear-gradient(180deg, #A3A3A3 0%, rgba(63, 63, 63, 0.6) 100%);',
+    },
+    angular: {
+        purple: 'conic-gradient(from 131.49deg at 51.11% 48.33%, #B9A1CF -37.5deg, #635273 176.25deg, #B9A1CF 322.5deg, #635273 536.25deg);',
+        gray: 'conic-gradient(from 131.49deg at 51.11% 48.33%, #868686 -37.5deg, #464447 176.25deg, #868686 322.5deg, #464447 536.25deg);',
+        pink: 'conic-gradient(from 180deg at 50% 50%, #EA386E -176.25deg, #E6A4B8 176.25deg, #EA386E 183.75deg, #E6A4B8 536.25deg);',
+    },
+    white: 'rgba(238, 239, 243, 0.95)',
+    navy: '#1D1A23',
+    gray0: '#262626',
+    gray1: '#9E9E9E',
+    gray2: '#DCDCDC',
+}
+
+export default colors

--- a/src/styles/theme/fonts.ts
+++ b/src/styles/theme/fonts.ts
@@ -1,0 +1,36 @@
+const fonts = {
+    title26: `
+      font-weight: 700;
+      font-size: 26px;
+    `,
+    title24: `
+      font-weight: 700;
+      font-size: 24px;
+    `,
+    title20: `
+      font-weight: 600;
+      font-size: 20px;
+    `,
+    title16: `
+      font-weight: 600;
+      font-size: 16px;
+    `,
+    text14: `
+      font-weight: 500;
+      font-size: 14px;
+    `,
+    text13: `
+      font-weight: 400;
+      font-size: 13px;
+    `,
+    text12: `
+      font-weight: 700;
+      font-size: 12px;
+    `,
+    caption11: `
+      font-weight: 600;
+      font-size: 11px;
+    `,
+}
+
+export default fonts

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -1,0 +1,13 @@
+import colors from '@/styles/theme/colors'
+import fonts from '@/styles/theme/fonts'
+import layouts from '@/styles/theme/layouts'
+
+// NOTE: 예시 사용 방법 (추후 삭제 예정)
+// color: ${({ theme }) => theme.colors.white};
+// ${({ theme }) => theme.fonts.text26}
+
+const theme = {
+    fonts,
+}
+
+export default theme

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -8,6 +8,7 @@ import layouts from '@/styles/theme/layouts'
 
 const theme = {
     fonts,
+    colors,
 }
 
 export default theme

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -9,6 +9,7 @@ import layouts from '@/styles/theme/layouts'
 const theme = {
     fonts,
     colors,
+    layouts,
 }
 
 export default theme

--- a/src/styles/theme/layouts.ts
+++ b/src/styles/theme/layouts.ts
@@ -1,0 +1,72 @@
+const layouts = {
+    // flex-row
+    flexStart: `
+      display: flex;
+      justify-contents: flex-start;
+      align-items: center;
+    `,
+    flexEnd: `
+      display: flex;
+      justify-contents: flex-end;
+      align-items: center;
+    `,
+    flexCenter: `
+      display: flex;
+      justify-contents: center;
+      align-items: center;
+    `,
+    flexBetween: `
+      display: flex;
+      justify-contents: space-between;
+      align-items: center;
+    `,
+    flexAround: `
+      display: flex;
+      justify-contents: space-around;
+      align-items: center;
+    `,
+    flexEvenly: `
+      display: flex;
+      justify-contents: space-evenly;
+      align-items: center;
+    `,
+    // flex-column
+    flexStartColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: flex-start;
+      align-items: center;
+    `,
+    flexEndColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: flex-end;
+      align-items: center;
+    `,
+    flexCenterColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: center;
+      align-items: center;
+    `,
+    flexBetweenColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: space-between;
+      align-items: center;
+    `,
+    flexAroundColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: space-around;
+      align-items: center;
+    `,
+    flexEvenlyColumn: `
+      display: flex;
+      flex-direction: column;
+      justify-contents: space-evenly;
+      align-items: center;
+    `,
+}
+
+export default layouts


### PR DESCRIPTION
## 구현 내용
- text, color, layout 디자인 테마 세팅
- styled-component는 js여서 대쉬(-)를 사용할수 없어 제거하고 `title-26 -> title26` 으로 세팅했습니다. 



> 헨리의 요청으로 layout도 만들었습니다! (ex, flexCenter)
> 추가해야할 내용이 있다면 추가해서 사용하면 될것 같아요


## 사용 방법
```
color: ${({ theme }) => theme.colors.white};
${({ theme }) => theme.fonts.text26}
```

## 참고 자료
- https://tailwindcss.com/docs/font-size
- https://wonit.tistory.com/366